### PR TITLE
Treat absent 'build' as 'host' (and absent 'host' same as 'run')

### DIFF
--- a/src/pyproject_external/_registry.py
+++ b/src/pyproject_external/_registry.py
@@ -255,6 +255,13 @@ class Mapping(UserDict, _Validated, _FromPathOrUrlOrDefault):
         if isinstance(specs, str):
             specs = {"build": [specs], "host": [specs], "run": [specs]}
         elif hasattr(specs, "items"):  # assert all fields are present as lists
+            # TODO: Review if this is an ok assumption.
+            # Absent fields let other fields fill in following this order:
+            # run > host > field. To really remove a category, it must be set to [] 
+            if "host" not in specs and (run_specs := specs.get("run")):
+                specs["host"] = run_specs
+            if "build" not in specs and (host_specs := specs.get("host")):
+                specs["build"] = host_specs
             for key in "build", "host", "run":
                 specs.setdefault(key, [])
                 if isinstance(specs[key], str):

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -31,6 +31,30 @@ def test_external():
     )
 
 
+def test_libyaml_host_as_build():
+    toml = dedent(
+        """
+        [external]
+        build-requires = ["dep:generic/libyaml"]
+        """
+    )
+    ext = External.from_pyproject_data(tomllib.loads(toml))
+    assert len(ext.build_requires) == 1
+    assert ext.build_requires[0] == DepURL.from_string("dep:generic/libyaml")
+    assert ext.map_dependencies(
+        "fedora",
+        key="build_requires",  # note mapping only has host deps for this one
+        package_manager="dnf",
+    ) == ["libyaml", "libyaml-devel"]
+    assert set(["dnf", "install", "libyaml", "libyaml-devel"]).issubset(
+        ext.install_command(
+            "fedora",
+            key="build_requires",
+            package_manager="dnf",
+        )
+    )
+
+
 def test_external_optional():
     toml = dedent(
         """


### PR DESCRIPTION
This allows mappings like `libyaml`:

```js
{
  "id": "dep:generic/libyaml",
  "description": "A C library for parsing and emitting YAML",
  "specs": {
    // absent "build" key
    "host": [
      "libyaml",
      "libyaml-devel"
    ],
    "run": [
      "libyaml"
    ],
  },
  "urls": {
    "packages.fedoraproject.org (libyaml)": "https://packages.fedoraproject.org/pkgs/libyaml/libyaml/",
    "packages.fedoraproject.org (libyaml-devel)": "https://packages.fedoraproject.org/pkgs/libyaml/libyaml-devel/"
  }
}
```

to be used with (perhaps incorrect) `[external]` tables like this:

```toml
[external]
build-requires = [
  "dep:virtual/compiler/c",
  "dep:generic/libyaml",
]
```

