### PR TITLE
Extend API for system property detections

### DIFF
--- a/src/pyproject_external/__init__.py
+++ b/src/pyproject_external/__init__.py
@@ -6,7 +6,7 @@ pyproject-external - Utilities to work with PEP 725 `[external]` metadata
 
 from ._external import External  # noqa
 from ._registry import Registry, Ecosystems, Mapping, default_ecosystems, remote_mapping  # noqa
-from ._system import detect_ecosystem, detect_ecosystem_and_package_manager
+from ._system import find_ecosystem_for_package_manager, detect_ecosystem_and_package_manager
 from ._url import DepURL  # noqa
 
 __all__ = [
@@ -15,7 +15,7 @@ __all__ = [
     "External",
     "Mapping",
     "Registry",
-    "detect_ecosystem",
+    "find_ecosystem_for_package_manager",
     "detect_ecosystem_and_package_manager",
     "default_ecosystems",
     "remote_mapping",

--- a/src/pyproject_external/__init__.py
+++ b/src/pyproject_external/__init__.py
@@ -5,7 +5,8 @@ pyproject-external - Utilities to work with PEP 725 `[external]` metadata
 """
 
 from ._external import External  # noqa
-from ._registry import Registry, Ecosystems, Mapping  # noqa
+from ._registry import Registry, Ecosystems, Mapping, default_ecosystems, remote_mapping  # noqa
+from ._system import detect_ecosystem, detect_ecosystem_and_package_manager
 from ._url import DepURL  # noqa
 
 __all__ = [
@@ -14,6 +15,10 @@ __all__ = [
     "External",
     "Mapping",
     "Registry",
+    "detect_ecosystem",
+    "detect_ecosystem_and_package_manager",
+    "default_ecosystems",
+    "remote_mapping",
 ]
 
 

--- a/src/pyproject_external/_cli.py
+++ b/src/pyproject_external/_cli.py
@@ -20,7 +20,7 @@ from rich.logging import RichHandler
 from rich.markup import escape
 
 # Only import from __init__ to make sure the only uses the public interface
-from . import External, detect_ecosystem, detect_ecosystem_and_package_manager
+from . import External, find_ecosystem_for_package_manager, detect_ecosystem_and_package_manager
 
 
 logging.basicConfig(
@@ -101,7 +101,7 @@ def main(
         return
 
     if package_manager:
-        ecosystem = detect_ecosystem(package_manager)
+        ecosystem = find_ecosystem_for_package_manager(package_manager)
     else:
         ecosystem, package_manager = detect_ecosystem_and_package_manager()
     log.info("Detected ecosystem '%s' for package manager '%s'", ecosystem, package_manager)

--- a/src/pyproject_external/_registry.py
+++ b/src/pyproject_external/_registry.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 from collections import UserDict
+from functools import cache
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -352,3 +353,15 @@ class Mapping(UserDict, _Validated, _FromPathOrUrlOrDefault):
         if not set(value).intersection("<>=!~"):
             return f"==={value}"
         return value
+
+
+@cache
+def default_ecosystems() -> Ecosystems:
+    return Ecosystems.from_default()
+
+
+@cache
+def remote_mapping(ecosystem_or_url: str) -> Mapping:
+    if ecosystem_or_url.startswith(("http://", "https://")):
+        return Mapping.from_url(ecosystem_or_url)
+    return Mapping.from_default(ecosystem_or_url)

--- a/src/pyproject_external/_system.py
+++ b/src/pyproject_external/_system.py
@@ -20,13 +20,12 @@ def find_ecosystem_for_package_manager(package_manager: str) -> str:
 
 
 def detect_ecosystem_and_package_manager() -> tuple[str, str]:
-    for name in (distro.id(), distro.like()):
+    distro_id = distro.id()
+    for name in (distro_id, *distro.like().split()):
         if name == "darwin":
             return "homebrew", "brew"
         mapping = default_ecosystems().get_mapping(name, default=None)
         if mapping:
             return name, mapping.package_managers[0]["name"]
 
-    log.warning("No support for distro %s yet", distro.id())
-    # FIXME
-    return "fedora", "dnf"
+    raise ValueError(f"No support for platform '{distro_id}' yet!")

--- a/src/pyproject_external/_system.py
+++ b/src/pyproject_external/_system.py
@@ -7,7 +7,7 @@ from ._registry import default_ecosystems, remote_mapping
 log = logging.getLogger(__name__)
 
 
-def detect_ecosystem(package_manager: str) -> str:
+def find_ecosystem_for_package_manager(package_manager: str) -> str:
     for ecosystem, mapping in default_ecosystems().iter_items():
         mapping = remote_mapping(mapping["mapping"])
         try:
@@ -16,7 +16,7 @@ def detect_ecosystem(package_manager: str) -> str:
             continue
         else:
             return ecosystem
-    raise ValueError(f"No ecosystem detected for package manager '{package_manager}'")
+    raise ValueError(f"No ecosystem found for package manager '{package_manager}'")
 
 
 def detect_ecosystem_and_package_manager() -> tuple[str, str]:

--- a/src/pyproject_external/_system.py
+++ b/src/pyproject_external/_system.py
@@ -1,0 +1,32 @@
+import logging
+
+import distro
+
+from ._registry import default_ecosystems, remote_mapping
+
+log = logging.getLogger(__name__)
+
+
+def detect_ecosystem(package_manager: str) -> str:
+    for ecosystem, mapping in default_ecosystems().iter_items():
+        mapping = remote_mapping(mapping["mapping"])
+        try:
+            mapping.get_package_manager(package_manager)
+        except ValueError:
+            continue
+        else:
+            return ecosystem
+    raise ValueError(f"No ecosystem detected for package manager '{package_manager}'")
+
+
+def detect_ecosystem_and_package_manager() -> tuple[str, str]:
+    for name in (distro.id(), distro.like()):
+        if name == "darwin":
+            return "homebrew", "brew"
+        mapping = default_ecosystems().get_mapping(name, default=None)
+        if mapping:
+            return name, mapping.package_managers[0]["name"]
+
+    log.warning("No support for distro %s yet", distro.id())
+    # FIXME
+    return "fedora", "dnf"

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -1,0 +1,23 @@
+import os
+import sys
+
+import pytest
+
+from pyproject_external import detect_ecosystem_and_package_manager
+
+pytestmark = pytest.mark.skipif(not os.environ.get("CI"), reason="On CI only.")
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Only for Ubuntu")
+def test_ubuntu():
+    assert detect_ecosystem_and_package_manager() == ("ubuntu", "apt-get")
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="Only for macOS")
+def test_macos():
+    assert detect_ecosystem_and_package_manager() == ("homebrew", "brew")
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Only for Windows")
+def test_windows():
+    assert detect_ecosystem_and_package_manager() == ("win32", "vcpkg")


### PR DESCRIPTION
These were hidden in the CLI before but might be useful elsewhere, after prototyping some changes in `mesonpy` that didn't go anywhere. I still felt the need for such an API to bring parity to the CLI functionality.