### PR TITLE
Validate `dep:virtual/*` URLs

### DIFF
--- a/src/pyproject_external/_constants.py
+++ b/src/pyproject_external/_constants.py
@@ -29,23 +29,3 @@ DEFAULT_REGISTRY_URL: Final[str] = (
     "https://raw.githubusercontent.com/jaimergp/external-metadata-mappings/main/"
     "data/registry.json"
 )
-VALID_LANGUAGES: Final[tuple[str]] = (
-    "c",
-    "c-sharp",
-    "c++",
-    "cpp",  # alias of c++
-    "cxx",  # alias of c++
-    "cuda",
-    "fortran",
-    "go",
-    "obj-c",
-    "objective-c",  # alias of obj-c
-    "rust",
-    "swift",
-)
-VALID_INTERFACES: Final[tuple[str]] = (
-    "blas",
-    "lapack",
-    "mpi",
-    "openmp",
-)

--- a/src/pyproject_external/_constants.py
+++ b/src/pyproject_external/_constants.py
@@ -29,3 +29,23 @@ DEFAULT_REGISTRY_URL: Final[str] = (
     "https://raw.githubusercontent.com/jaimergp/external-metadata-mappings/main/"
     "data/registry.json"
 )
+VALID_LANGUAGES: Final[tuple[str]] = (
+    "c",
+    "c-sharp",
+    "c++",
+    "cpp",  # alias of c++
+    "cxx",  # alias of c++
+    "cuda",
+    "fortran",
+    "go",
+    "obj-c",
+    "objective-c",  # alias of obj-c
+    "rust",
+    "swift",
+)
+VALID_INTERFACES: Final[tuple[str]] = (
+    "blas",
+    "lapack",
+    "mpi",
+    "openmp",
+)

--- a/src/pyproject_external/_external.py
+++ b/src/pyproject_external/_external.py
@@ -306,11 +306,14 @@ class External:
             self._validate_url(url, canonical=canonical)
 
     def _validate_url(self, url: DepURL, canonical: bool = True) -> None:
-        unique_ids = set(DepURL.from_string(id_) for id_ in self.registry.iter_unique_ids())
-        if url not in unique_ids:
-            choices = [str(id_) for id_ in unique_ids]
+        unique_urls = set()
+        unique_strs = []
+        for id_ in self.registry.iter_unique_ids():
+            unique_strs.append(id_)
+            unique_urls.add(DepURL.from_string(id_))
+        if url not in unique_urls:
             most_similar = sorted(
-                choices,
+                unique_strs,
                 key=lambda i: SequenceMatcher(None, str(url), i).ratio(),
                 reverse=True,
             )[:5]

--- a/src/pyproject_external/_url.py
+++ b/src/pyproject_external/_url.py
@@ -12,8 +12,6 @@ from urllib.parse import unquote
 
 from packageurl import PackageURL
 
-from ._constants import VALID_INTERFACES, VALID_LANGUAGES
-
 if TYPE_CHECKING:
     from typing import AnyStr, ClassVar
 
@@ -55,7 +53,6 @@ class DepURL(PackageURL):
             subpath=subpath,
         )
         return inst
-
 
     def to_string(self) -> str:
         # Parent class forces quoting on qualifiers and some others, we don't want that.

--- a/src/pyproject_external/_url.py
+++ b/src/pyproject_external/_url.py
@@ -36,25 +36,14 @@ class DepURL(PackageURL):
         subpath: AnyStr | None = None,
     ) -> Self:
         # Validate virtual types _before_ the namedtuple is created
-        if type == "virtual":
-            # names are normalized to lowercase
-            name = name.lower()
-            if namespace == "compiler":
-                if name not in VALID_LANGUAGES:
-                    raise ValueError(
-                        "'dep:virtual/compiler/*' only accepts the following "
-                        f"languages as 'name': {VALID_LANGUAGES}"
-                    )
-            elif namespace == "interface":
-                if name not in VALID_INTERFACES:
-                    raise ValueError(
-                        "'dep:virtual/interface/*' only accepts the following "
-                        f"interfaces as 'name': {VALID_INTERFACES}"
-                    )
-            else:
+        if type.lower() == "virtual":
+            namespace = namespace.lower()
+            if namespace not in ("compiler", "interface"):
                 raise ValueError(
                     "'dep:virtual/*' only accepts 'compiler' or 'interface' as namespace."
                 )
+            # names are normalized to lowercase
+            name = name.lower()
 
         inst = super().__new__(
             cls,


### PR DESCRIPTION
These are not covered upstream, so we have to do it ourselves _before_ the namedtuple is initialized (hence why we are acting on `__new__`).

Controversial points:

- The list of (compiled) languages for `dep:virtual/compiler/*`.
  - Should we allow aliases? If so, should they get normalized to the canonical one? e.g. `cpp` becomes `c++`? Which one should be the canonical one?
- The list of interfaces for `dep:virtual/interface/*`. Anything I'm missing? Do we need aliases here?

I've also decided to lowercase everything.