### PR TITLE
Improve "not on CI" error with a shared exception

### DIFF
--- a/src/pyproject_external/_cli/_utils.py
+++ b/src/pyproject_external/_cli/_utils.py
@@ -27,3 +27,13 @@ def _pyproject_text(package: Path) -> str:
 class _Installers(str, Enum):
     pip = "pip"
     uv = "uv"
+
+
+class NotOnCIError(RuntimeError):
+    def __init__(self):
+        super().__init__(
+            "This tool should only be used in CI or ephemeral environments!\n\n"
+            "It will likely install system packages as a side effect of providing the "
+            "external dependencies required to build the wheels.\n\n"
+            "If you understand the risks, set CI=1 to override."
+        )

--- a/src/pyproject_external/_cli/build.py
+++ b/src/pyproject_external/_cli/build.py
@@ -30,7 +30,7 @@ from .. import (
     detect_ecosystem_and_package_manager,
     find_ecosystem_for_package_manager,
 )
-from ._utils import _Installers, _pyproject_text
+from ._utils import NotOnCIError, _Installers, _pyproject_text
 
 log = logging.getLogger(__name__)
 app = typer.Typer()
@@ -69,7 +69,7 @@ def build(
     unknown_args: typer.Context = typer.Option(()),
 ) -> None:
     if not os.environ.get("CI"):
-        raise RuntimeError("This tool can only be used in CI environments. Set CI=1 to override.")
+        raise NotOnCIError()
 
     package = Path(package)
     pyproject_text = _pyproject_text(package)

--- a/src/pyproject_external/_cli/install.py
+++ b/src/pyproject_external/_cli/install.py
@@ -28,7 +28,7 @@ from .. import (
     detect_ecosystem_and_package_manager,
     find_ecosystem_for_package_manager,
 )
-from ._utils import _Installers, _pyproject_text
+from ._utils import NotOnCIError, _Installers, _pyproject_text
 
 log = logging.getLogger(__name__)
 
@@ -62,7 +62,7 @@ def install(
     unknown_args: typer.Context = typer.Option(()),
 ) -> None:
     if not os.environ.get("CI"):
-        raise RuntimeError("This tool can only be used in CI environments. Set CI=1 to override.")
+        raise NotOnCIError()
 
     package = Path(package)
     pyproject_text = _pyproject_text(package)


### PR DESCRIPTION
Provide rationale behind the `CI` guards so users think twice before overriding.

cc @rgommers 