### PR TITLE
Drop group names from group tuples while validating

### DIFF
--- a/src/pyproject_external/_external.py
+++ b/src/pyproject_external/_external.py
@@ -297,6 +297,8 @@ class External:
         """
         exceptions = []
         for url in chain(self.iter(), self.iter_optional()):
+            if isinstance(url, tuple):
+                url = url[1]  # drop group name that might come from extras and optional deps
             try:
                 self._validate_url(url, canonical=canonical, raises=raises)
             except ValueError as exc:

--- a/src/pyproject_external/_external.py
+++ b/src/pyproject_external/_external.py
@@ -296,13 +296,17 @@ class External:
         :warns: Whether one or more DepURLs are not part of the central registry or canonical.
         """
         exceptions = []
+        seen = set()
         for url in chain(self.iter(), self.iter_optional()):
             if isinstance(url, tuple):
                 url = url[1]  # drop group name that might come from extras and optional deps
+            if url in seen:
+                continue
             try:
                 self._validate_url(url, canonical=canonical, raises=raises)
             except ValueError as exc:
                 exceptions.append(exc)
+            seen.add(url)
         if exceptions:
             raise ExceptionGroup("Validation errors", exceptions)
 

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -18,6 +18,7 @@ def test_external():
         """
     )
     ext: External = External.from_pyproject_data(tomllib.loads(toml))
+    ext.validate()
     assert len(ext.build_requires) == 1
     assert ext.build_requires[0] == DepURL.from_string("dep:virtual/compiler/c")
     assert ext.map_dependencies(
@@ -44,7 +45,8 @@ def test_external_optional():
         ]
         """
     )
-    ext = External.from_pyproject_data(tomllib.loads(toml))
+    ext: External = External.from_pyproject_data(tomllib.loads(toml))
+    ext.validate()
     assert len(ext.optional_build_requires) == 1
     assert len(ext.optional_build_requires["extra"]) == 3
     assert ext.optional_build_requires["extra"] == [


### PR DESCRIPTION
Fixes issue while validating `[external]` tables with extras and optional dependencies.